### PR TITLE
refactor(box): use parameters in code to token exchange

### DIFF
--- a/app/connectors/connectors/box-connector/src/main/resources/META-INF/syndesis/connector/box.json
+++ b/app/connectors/connectors/box-connector/src/main/resources/META-INF/syndesis/connector/box.json
@@ -13,7 +13,8 @@
     "configuredProperties": {
         "tokenUrl": "https://api.box.com/oauth2/token",
         "authorizationUrl": "https://account.box.com/api/oauth2/authorize",
-        "authenticationType": "oauth2"
+        "authenticationType": "oauth2",
+        "useParametersForClientCredentials": "true"
     },
     "tags": [
         "verifier"
@@ -113,6 +114,22 @@
             "secret": true,
             "componentProperty": true,
             "description": "Authentication Type"
+        },
+        "useParametersForClientCredentials": {
+            "kind": "property",
+            "displayName": "Use OAuth parameters",
+            "group": "security",
+            "label": "security",
+            "required": false,
+            "type": "string",
+            "javaType": "java.lang.String",
+            "tags": [
+                "oauth-authorize-using-parameters"
+            ],
+            "deprecated": false,
+            "secret": true,
+            "componentProperty": true,
+            "description": "Use OAuth parameters in authorization code to oauth token exchange"
         }
     },
     "actions": [


### PR DESCRIPTION
Configures the `oauth-authorize-using-parameters`-tagged property in
order to send the `client_id` and `client_secret` when performing the
exchange of authorization code to authorization token.